### PR TITLE
fix(dashboard): neutralize spreadsheet formulas in BQL CSV export

### DIFF
--- a/dashboard/src/features/bql/lib/__tests__/export-utils.test.ts
+++ b/dashboard/src/features/bql/lib/__tests__/export-utils.test.ts
@@ -114,7 +114,7 @@ describe("export-utils", () => {
       );
     });
 
-    it("should handle formula injection attempts", () => {
+    it("should neutralize formula injection attempts", () => {
       const result: QueryResultTable = {
         types: [{ name: "formula", dtype: "str" }],
         rows: [
@@ -123,17 +123,42 @@ describe("export-utils", () => {
           ["+1+1"],
           ["-1+1"],
           ["@SUM(A1:A10)"],
+          ["\t=1+1"],
+          ["  =1+1"],
+        ],
+      } as any;
+
+      const csv = tableToCSV(result);
+      const lines = csv.split("\n");
+
+      // Dangerous prefixes become inert text via a leading apostrophe
+      expect(lines).toEqual([
+        "formula",
+        "'=1+1",
+        "'=cmd|'/c calc'!A1",
+        "'+1+1",
+        "'-1+1",
+        "'@SUM(A1:A10)",
+        "'\t=1+1",
+        "'  =1+1",
+      ]);
+    });
+
+    it("should keep plain numbers and negative amounts numeric", () => {
+      const result: QueryResultTable = {
+        types: [
+          { name: "amount", dtype: "Decimal" },
+          { name: "note", dtype: "str" },
+        ],
+        rows: [
+          [-42.5, "-42.50"],
+          [100, "+15"],
         ],
       } as any;
 
       const csv = tableToCSV(result);
 
-      // All formulas should be properly escaped
-      expect(csv).toContain("=1+1");
-      expect(csv).toContain("=cmd|'/c calc'!A1");
-      // These should be safe when quoted
-      const lines = csv.split("\n");
-      expect(lines.length).toBe(6); // header + 5 rows
+      expect(csv).toBe("amount,note\n-42.5,-42.50\n100,+15");
     });
 
     it("should handle empty strings", () => {

--- a/dashboard/src/features/bql/lib/export-utils.ts
+++ b/dashboard/src/features/bql/lib/export-utils.ts
@@ -1,5 +1,23 @@
 import type { QueryResultTable } from "@/graphql/definitions";
 
+// Cells starting with =, @, tab, or CR — or +/- unless the whole cell is a
+// plain number — are executed as formulas by Excel/Sheets/LibreOffice.
+const FORMULA_PREFIX = /^[\t\r]|^\s*[=+\-@]/;
+const PLAIN_NUMBER = /^[+-]?\d+(\.\d+)?$/;
+
+/**
+ * Force spreadsheet-dangerous text to inert text semantics.
+ * CSV quoting alone does not stop formula evaluation (CWE-1236), so prefix
+ * dangerous cells with an apostrophe, which spreadsheets treat as a text
+ * marker. Plain numbers (including negative amounts) are left untouched.
+ */
+function neutralizeSpreadsheetFormula(str: string): string {
+  if (!FORMULA_PREFIX.test(str) || PLAIN_NUMBER.test(str)) {
+    return str;
+  }
+  return `'${str}`;
+}
+
 /**
  * Escape CSV field value.
  * Fields containing quotes, commas, or newlines must be quoted.
@@ -16,6 +34,8 @@ function escapeCSVField(value: unknown): string {
   if (typeof value === "object") {
     str = JSON.stringify(value);
   }
+
+  str = neutralizeSpreadsheetFormula(str);
 
   // Check if field needs quoting
   const needsQuoting = /[",\n\r]/.test(str);


### PR DESCRIPTION
## Summary
Security-scan finding 7 (low, CWE-1236): free-form ledger text (payee, narration, query results) passed through CSV quoting with formula prefixes intact, so a hostile cell like `=cmd|'/c calc'!A1` became a live formula when the exported CSV was opened in Excel/Sheets.

- Cells starting with `=`, `@`, tab, or CR — or `+`/`-` when the whole cell is not a plain number — get an apostrophe prefix (spreadsheet text marker) before CSV quoting.
- Plain numbers, including negative amounts, stay numeric — important for an accounting export.
- The old test asserted formulas survive (codifying the vulnerable behavior); it now asserts neutralization.

## Known follow-up
Exponent-notation numerics (`String(-1e-7)` → `"-1e-7"`) currently get neutralized to text; a follow-up will extend the safe-number pattern (review finding, P2).

## Testing
- Updated + new tests cover all dangerous prefixes, tab/space-led variants, and numeric preservation. `vitest`, `tsc`, ESLint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)