### PR TITLE
fix(cli): create credentials file atomically with 0600 permissions

### DIFF
--- a/cli/src/cli/auth/credentials.py
+++ b/cli/src/cli/auth/credentials.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import stat
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -21,9 +22,22 @@ class Credentials:
 
 
 def save_credentials(token: str, expire_at: str) -> None:
+    # Create the file as 0600 inside a 0700 directory from the start — a
+    # write-then-chmod sequence leaks the token under a permissive umask.
     CREDENTIALS_DIR.mkdir(parents=True, exist_ok=True)
-    CREDENTIALS_PATH.write_text(json.dumps({"token": token, "expireAt": expire_at}, indent=2))
-    CREDENTIALS_PATH.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    CREDENTIALS_DIR.chmod(stat.S_IRWXU)
+    payload = json.dumps({"token": token, "expireAt": expire_at}, indent=2)
+    tmp_path = CREDENTIALS_PATH.with_name(CREDENTIALS_PATH.name + ".tmp")
+    tmp_path.unlink(missing_ok=True)
+    fd = os.open(tmp_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, stat.S_IRUSR | stat.S_IWUSR)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(payload)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, CREDENTIALS_PATH)
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 def load_credentials() -> Credentials | None:

--- a/cli/tests/test_credentials.py
+++ b/cli/tests/test_credentials.py
@@ -1,6 +1,7 @@
 """Tests for credential storage."""
 
 import json
+import os
 import stat
 from pathlib import Path
 from unittest.mock import patch
@@ -46,6 +47,38 @@ class TestSaveLoadClear:
             assert loaded is not None
             assert loaded.token == "my-token"
             assert loaded.expire_at == "2099-01-01T00:00:00Z"
+
+    def test_save_is_0600_under_permissive_umask(self, tmp_path: Path) -> None:
+        cred_dir = tmp_path / "creds"
+        cred_path = cred_dir / "credentials.json"
+        old_umask = os.umask(0o022)
+        try:
+            with (
+                patch("cli.auth.credentials.CREDENTIALS_DIR", cred_dir),
+                patch("cli.auth.credentials.CREDENTIALS_PATH", cred_path),
+            ):
+                save_credentials("my-token", "2099-01-01T00:00:00Z")
+        finally:
+            os.umask(old_umask)
+
+        assert stat.S_IMODE(cred_path.stat().st_mode) == stat.S_IRUSR | stat.S_IWUSR
+        assert stat.S_IMODE(cred_dir.stat().st_mode) == stat.S_IRWXU
+        assert not cred_path.with_name(cred_path.name + ".tmp").exists()
+
+    def test_save_tightens_existing_loose_file(self, tmp_path: Path) -> None:
+        cred_path = tmp_path / "credentials.json"
+        cred_path.write_text("{}")
+        cred_path.chmod(0o644)
+        with (
+            patch("cli.auth.credentials.CREDENTIALS_DIR", tmp_path),
+            patch("cli.auth.credentials.CREDENTIALS_PATH", cred_path),
+        ):
+            save_credentials("new-token", "2099-01-01T00:00:00Z")
+
+            assert stat.S_IMODE(cred_path.stat().st_mode) == stat.S_IRUSR | stat.S_IWUSR
+            loaded = load_credentials()
+            assert loaded is not None
+            assert loaded.token == "new-token"
 
     def test_load_returns_none_if_missing(self, tmp_path: Path) -> None:
         cred_path = tmp_path / "credentials.json"


### PR DESCRIPTION
## Summary
Security-scan finding 5 (low, CWE-732): `save_credentials` wrote the plaintext bearer token with umask-derived permissions (0644 under umask 022) and only chmod'ed to 0600 afterwards — an interruption between the two left the token readable by other local users.

- Create `~/.beancount-cli` as 0700.
- Write the token to an `O_CREAT|O_EXCL` 0600 temp file, `fsync`, then atomically `os.replace` into place — the file is never observable with loose permissions, and overwriting a legacy 0644 file tightens it.

## Known follow-up
The temp path is shared across invocations; two concurrent logins could race (review finding, P2). Follow-up: unique temp name via `tempfile.mkstemp`.

## Testing
- New tests: 0600 from first observable creation under umask 022 (plus 0700 dir, no leftover temp), and tightening of a pre-existing 0644 file. `make check-all` green (53 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)