### PR TITLE
fix(mobile): store session token in Keychain/Keystore via expo-secure-store

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -107,7 +107,8 @@
       "expo-web-browser",
       "@react-native-community/datetimepicker",
       "@sentry/react-native",
-      "expo-status-bar"
+      "expo-status-bar",
+      "expo-secure-store"
     ],
     "extra": {
       "eas": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -50,6 +50,7 @@
     "expo-localization": "~57.0.0",
     "expo-mixpanel-analytics": "0.0.7",
     "expo-router": "~57.0.4",
+    "expo-secure-store": "~57.0.1",
     "expo-splash-screen": "~57.0.2",
     "expo-status-bar": "~57.0.0",
     "expo-store-review": "~57.0.0",

--- a/mobile/src/common/apollo/__tests__/secure-session-storage.test.ts
+++ b/mobile/src/common/apollo/__tests__/secure-session-storage.test.ts
@@ -1,0 +1,112 @@
+describe("secureSessionStorage", () => {
+  const secureStorePath = require.resolve("expo-secure-store");
+  const asyncStoragePath =
+    require.resolve("@react-native-async-storage/async-storage");
+
+  let originalSecureStoreModule: NodeModule | undefined;
+  let originalAsyncStorageModule: NodeModule | undefined;
+
+  const secureStoreMock = {
+    getItemAsync: async (_key: string) => null as string | null,
+    setItemAsync: async (_key: string, _value: string) => {},
+  };
+
+  const asyncStorageMock = {
+    getItem: async (_key: string) => null as string | null,
+    removeItem: async (_key: string) => {},
+  };
+
+  let secureSessionStorage: typeof import("../secure-session-storage").secureSessionStorage;
+
+  beforeEach(() => {
+    originalSecureStoreModule = require.cache[secureStorePath];
+    originalAsyncStorageModule = require.cache[asyncStoragePath];
+
+    secureStoreMock.getItemAsync = async () => null;
+    secureStoreMock.setItemAsync = async () => {};
+    asyncStorageMock.getItem = async () => null;
+    asyncStorageMock.removeItem = async () => {};
+
+    require.cache[secureStorePath] = {
+      exports: secureStoreMock,
+    } as NodeModule;
+    require.cache[asyncStoragePath] = {
+      exports: asyncStorageMock,
+    } as NodeModule;
+
+    const modulePath = require.resolve("../secure-session-storage");
+    delete require.cache[modulePath];
+    ({ secureSessionStorage } = require("../secure-session-storage"));
+  });
+
+  afterEach(() => {
+    const modulePath = require.resolve("../secure-session-storage");
+    delete require.cache[modulePath];
+
+    if (originalSecureStoreModule) {
+      require.cache[secureStorePath] = originalSecureStoreModule;
+    } else {
+      delete require.cache[secureStorePath];
+    }
+
+    if (originalAsyncStorageModule) {
+      require.cache[asyncStoragePath] = originalAsyncStorageModule;
+    } else {
+      delete require.cache[asyncStoragePath];
+    }
+  });
+
+  it("returns the secure value without touching AsyncStorage", async () => {
+    const legacyReads: string[] = [];
+    secureStoreMock.getItemAsync = async (key: string) =>
+      key === "session" ? '{"userId":"u1"}' : null;
+    asyncStorageMock.getItem = async (key: string) => {
+      legacyReads.push(key);
+      return null;
+    };
+
+    const value = await secureSessionStorage.getItem("session");
+
+    expect(value).toBe('{"userId":"u1"}');
+    expect(legacyReads).toEqual([]);
+  });
+
+  it("migrates a legacy AsyncStorage value into secure storage", async () => {
+    const secureWrites: Array<{ key: string; value: string }> = [];
+    const legacyRemovals: string[] = [];
+    asyncStorageMock.getItem = async (key: string) =>
+      key === "session" ? '{"userId":"legacy"}' : null;
+    secureStoreMock.setItemAsync = async (key: string, value: string) => {
+      secureWrites.push({ key, value });
+    };
+    asyncStorageMock.removeItem = async (key: string) => {
+      legacyRemovals.push(key);
+    };
+
+    const value = await secureSessionStorage.getItem("session");
+
+    expect(value).toBe('{"userId":"legacy"}');
+    expect(secureWrites).toEqual([
+      { key: "session", value: '{"userId":"legacy"}' },
+    ]);
+    expect(legacyRemovals).toEqual(["session"]);
+  });
+
+  it("returns null when neither store has a value", async () => {
+    const value = await secureSessionStorage.getItem("session");
+    expect(value).toBe(null);
+  });
+
+  it("writes only to secure storage", async () => {
+    const secureWrites: Array<{ key: string; value: string }> = [];
+    secureStoreMock.setItemAsync = async (key: string, value: string) => {
+      secureWrites.push({ key, value });
+    };
+
+    await secureSessionStorage.setItem("session", '{"authToken":"t"}');
+
+    expect(secureWrites).toEqual([
+      { key: "session", value: '{"authToken":"t"}' },
+    ]);
+  });
+});

--- a/mobile/src/common/apollo/persistent-var.ts
+++ b/mobile/src/common/apollo/persistent-var.ts
@@ -2,12 +2,19 @@
 import { makeVar, ReactiveVar } from "@apollo/client";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
+// 存储后端接口（默认 AsyncStorage；凭证类数据请传安全存储）
+export type PersistentStorage = {
+  getItem: (key: string) => Promise<string | null>;
+  setItem: (key: string, value: string) => Promise<void>;
+};
+
 // 定义泛型类型，支持任意类型的持久化变量
 export function createPersistentVar<T>(
-  key: string, // AsyncStorage 的键名
+  key: string, // 存储键名
   defaultValue: T, // 默认值（初始加载失败时使用）
   serialize?: (value: T) => string, // 序列化函数（默认 JSON.stringify）
   deserialize?: (value: string) => T, // 反序列化函数（默认 JSON.parse）
+  storage: PersistentStorage = AsyncStorage, // 存储后端
 ): [ReactiveVar<T>, () => Promise<T | null>] {
   // 初始化变量（内存中的响应式变量）
   const varInstance = makeVar<T>(defaultValue);
@@ -19,7 +26,7 @@ export function createPersistentVar<T>(
   // 加载存储的值并更新变量（异步）
   const loadFromStorage = async (): Promise<T | null> => {
     try {
-      const storedValue = await AsyncStorage.getItem(key);
+      const storedValue = await storage.getItem(key);
       if (storedValue !== null) {
         const result = deserializeValue(storedValue);
         varInstance(result); // 更新内存变量
@@ -36,7 +43,7 @@ export function createPersistentVar<T>(
   const saveToStorage = async (newValue: T): Promise<void> => {
     try {
       const serializedValue = serializeValue(newValue);
-      await AsyncStorage.setItem(key, serializedValue);
+      await storage.setItem(key, serializedValue);
     } catch (error) {
       console.error(`Failed to save ${key} to AsyncStorage:`, error);
     }

--- a/mobile/src/common/apollo/secure-session-storage.ts
+++ b/mobile/src/common/apollo/secure-session-storage.ts
@@ -1,0 +1,24 @@
+import * as SecureStore from "expo-secure-store";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import type { PersistentStorage } from "./persistent-var";
+
+// Bearer credentials must live in the OS keychain/keystore — AsyncStorage is
+// plaintext on disk. Reads fall back to the legacy AsyncStorage entry once,
+// migrating it into secure storage and deleting the plaintext copy.
+export const secureSessionStorage: PersistentStorage = {
+  async getItem(key: string): Promise<string | null> {
+    const secureValue = await SecureStore.getItemAsync(key);
+    if (secureValue !== null) {
+      return secureValue;
+    }
+    const legacyValue = await AsyncStorage.getItem(key);
+    if (legacyValue !== null) {
+      await SecureStore.setItemAsync(key, legacyValue);
+      await AsyncStorage.removeItem(key);
+    }
+    return legacyValue;
+  },
+  async setItem(key: string, value: string): Promise<void> {
+    await SecureStore.setItemAsync(key, value);
+  },
+};

--- a/mobile/src/common/vars/session.ts
+++ b/mobile/src/common/vars/session.ts
@@ -1,4 +1,5 @@
 import { createPersistentVar } from "@/common/apollo/persistent-var";
+import { secureSessionStorage } from "@/common/apollo/secure-session-storage";
 
 export type Session = {
   userId: string;
@@ -8,4 +9,7 @@ export type Session = {
 export const [sessionVar, loadSession] = createPersistentVar<Session | null>(
   "session",
   null,
+  undefined,
+  undefined,
+  secureSessionStorage,
 );

--- a/mobile/yarn.lock
+++ b/mobile/yarn.lock
@@ -5292,6 +5292,11 @@ expo-router@~57.0.4:
     standard-navigation "^0.0.5"
     vaul "^1.1.2"
 
+expo-secure-store@~57.0.1:
+  version "57.0.1"
+  resolved "https://registry.yarnpkg.com/expo-secure-store/-/expo-secure-store-57.0.1.tgz#746892729ca7a78513a1c220b48c1f3f803af413"
+  integrity sha512-tLa1VmSadOq19mA/dwkl99RbHyjLE0T1qqBYMY3/OsguZTI+rlrDy/DDJjupqlVtmr95hD7o1pYqx5aL+B4YMA==
+
 expo-server@^57.0.0:
   version "57.0.0"
   resolved "https://registry.yarnpkg.com/expo-server/-/expo-server-57.0.0.tgz#5b9d9a126008007dd998ba019a0bf0fa2a0fd387"


### PR DESCRIPTION
## Summary
Security-scan finding 4 (low, CWE-922): the replayable API bearer token was JSON-serialized into plaintext AsyncStorage and restored for `Authorization` headers.

- Add `expo-secure-store@57.0.1` (config plugin included in `app.json`); the session reactive var now persists through a Keychain/Keystore-backed adapter.
- One-time migration: on first read, a legacy AsyncStorage session is moved into secure storage and the plaintext copy deleted — deletion only runs after the secure write succeeds, so there is no token-loss window.
- `createPersistentVar` gains an optional storage backend — AsyncStorage remains the default for theme/locale/ledger.

## Release impact
**No version bump in this PR.** Merging deploys nothing: the deploy workflow gates both the OTA update and the EAS build on an untagged version (`needs_release`), and main stays on the already-tagged `1.20260731.40`. The change first reaches users with the next explicit `yarn bump`, which cuts a new binary containing the native module; because `runtimeVersion` policy is `appVersion`, the accompanying OTA targets only that new runtime — old binaries can never receive this JS.

Note for local development: rebuild your dev client (`expo run:ios` / `run:android`) after pulling — the JS references a native module your existing build doesn't contain.

## Testing
- 4 adapter unit tests (secure hit skips legacy store, migration moves + deletes, miss returns null, writes go to secure storage only); full mobile suite green (lint + typecheck + 1041 tests).
- Verified end-to-end in the iOS simulator dev build, including a seeded legacy-session migration with a realistic 1092-byte JWT: after first launch the AsyncStorage plaintext is deleted and the token appears in the simulator keychain (`genp` row 0 → 1); a control run on main leaves the plaintext in AsyncStorage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)